### PR TITLE
Update marine-sweep-width-data to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@canterbury-air-patrol/marine-sweep-width-data": "^0.1.0",
+        "@canterbury-air-patrol/marine-sweep-width-data": "^0.2.0",
         "jquery": "^3.7.0",
         "prop-types": "^15.8.1",
         "react": "^19.0.0",
@@ -40,9 +40,10 @@
       }
     },
     "node_modules/@canterbury-air-patrol/marine-sweep-width-data": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/marine-sweep-width-data/-/marine-sweep-width-data-0.1.0.tgz",
-      "integrity": "sha512-b7vlJIx98EGugQhm57ril1yQmKbLzbFwTYKvae0BZrBhdSMI4OPEkxsd2mqvF7z89ItfMWN5ZdHg0Dhf5UE3HQ=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@canterbury-air-patrol/marine-sweep-width-data/-/marine-sweep-width-data-0.2.0.tgz",
+      "integrity": "sha512-lZf4kPBlUzZPh5rY9DtnvpQ0vwpj6ExGzm/PeYfabzdKPw4UEg/r32DulPQSRgk9PHsPSQkNRzFmhZQxZVntWw==",
+      "license": "PDDL-1.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/canterbury-air-patrol/marine-search-area-coverage#readme",
   "dependencies": {
-    "@canterbury-air-patrol/marine-sweep-width-data": "^0.1.0",
+    "@canterbury-air-patrol/marine-sweep-width-data": "^0.2.0",
     "jquery": "^3.7.0",
     "prop-types": "^15.8.1",
     "react": "^19.0.0",


### PR DESCRIPTION
## Description

This updates provides typescript support

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Build:
- Update the dependency '@canterbury-air-patrol/marine-sweep-width-data' to version 0.2.0 in package.json.